### PR TITLE
Added sport specific form the appears for user to complete after session

### DIFF
--- a/log.html
+++ b/log.html
@@ -383,6 +383,59 @@
 
     </div><!-- end container -->
 
+    <!-- Common Fields — hidden until a sport is chosen -->
+    <div class="container pb-5" id="log-common-fields" hidden>
+        <div class="log-form-card">
+            <h4 class="log-form-title">Session Details</h4>
+            <div class="log-form-grid">
+
+                <!-- Date -->
+                <div class="form-group">
+                    <label for="log-date">Date</label>
+                    <input type="date" id="log-date" class="log-input">
+                </div>
+
+                <!-- Duration -->
+                <div class="form-group">
+                    <label for="log-duration">Duration (min)</label>
+                    <input type="number" id="log-duration" class="log-input" placeholder="0" min="0">
+                </div>
+
+                <!-- Effort / Intensity (1–5 radio buttons) -->
+                <div class="form-group">
+                    <label>Effort</label>
+                    <div class="log-effort-group">
+                        <label class="log-effort-label" title="Easy">
+                            <input type="radio" name="log-effort" value="1"> 1
+                        </label>
+                        <label class="log-effort-label" title="Light">
+                            <input type="radio" name="log-effort" value="2"> 2
+                        </label>
+                        <label class="log-effort-label" title="Moderate">
+                            <input type="radio" name="log-effort" value="3"> 3
+                        </label>
+                        <label class="log-effort-label" title="Hard">
+                            <input type="radio" name="log-effort" value="4"> 4
+                        </label>
+                        <label class="log-effort-label" title="Max effort">
+                            <input type="radio" name="log-effort" value="5"> 5
+                        </label>
+                    </div>
+                </div>
+
+            </div>
+
+            <!-- Notes -->
+            <div class="form-group" style="margin-top: 1rem;">
+                <label for="log-notes">Notes <span class="log-optional">optional</span></label>
+                <textarea id="log-notes" class="log-textarea" rows="3" placeholder="How did it go?"></textarea>
+            </div>
+
+            <!-- Submit -->
+            <button type="submit" class="btn-submit log-submit-btn">Save Session</button>
+        </div>
+    </div>
+
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="log.js"></script>
 </body>

--- a/log.js
+++ b/log.js
@@ -2,8 +2,13 @@
 
 // ── Sport selector ──────────────────────────────────────────────────────────
 
-const sportButtons = document.querySelectorAll('.lb-filter-btn[data-sport]');
-const sportForms   = document.querySelectorAll('.log-sport-form');
+const sportButtons   = document.querySelectorAll('.lb-filter-btn[data-sport]');
+const sportForms     = document.querySelectorAll('.log-sport-form');
+const commonFields   = document.getElementById('log-common-fields');
+
+// Default the date input to today when the page loads
+const dateInput = document.getElementById('log-date');
+dateInput.value = new Date().toISOString().split('T')[0];
 
 sportButtons.forEach(button => {
     button.addEventListener('click', () => {
@@ -17,6 +22,9 @@ sportButtons.forEach(button => {
         sportForms.forEach(form => {
             form.hidden = form.dataset.sport !== selectedSport;
         });
+
+        // Reveal the common session details section
+        commonFields.hidden = false;
     });
 });
 

--- a/styles.css
+++ b/styles.css
@@ -498,6 +498,50 @@ input[type="checkbox"] {
     font-size: 0.95rem;
 }
 
+/* Notes textarea */
+.log-textarea {
+    padding: 0.7rem 0.9rem;
+    background: #0f1117;
+    border: 1px solid #444;
+    border-radius: 6px;
+    color: #e8eaf0;
+    font-size: 1rem;
+    width: 100%;
+    resize: vertical;
+}
+
+.log-textarea:focus {
+    outline: none;
+    border-color: #00c896;
+    box-shadow: 0 0 0 3px rgba(0, 200, 150, 0.2);
+}
+
+/* Effort 1–5 radio group */
+.log-effort-group {
+    display: flex;
+    gap: 1rem;
+    margin-top: 0.5rem;
+}
+
+.log-effort-label {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    color: #e8eaf0;
+    cursor: pointer;
+    font-size: 0.95rem;
+}
+
+/* Submit button — full width within the card */
+.log-submit-btn {
+    margin-top: 1.5rem;
+    padding: 12px 32px;
+    border: none;
+    border-radius: 8px;
+    font-size: 1rem;
+    cursor: pointer;
+}
+
 /* "optional" hint text on labels */
 .log-optional {
     font-size: 0.75rem;


### PR DESCRIPTION
When a sport pill is clicked, the sport-specific form appears followed by the "Session Details" card containing:

Date (pre-filled with today's date)
Duration (number input in minutes)
Effort (1–5 radio buttons)
Notes (resizable textarea)
Save Session (uses the .btn-submit class your teammate already added to styles.css)

still not functional at all and some bugs still need to be fixed with it (this is just an initial push for this section of the page).