### PR TITLE
feat: add base Jinja template

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}FitScore{% endblock %}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+    {% block extra_css %}{% endblock %}
+</head>
+<body>
+
+    <!-- Navbar -->
+    <nav class="navbar navbar-dark px-4">
+        <span class="navbar-brand">FitScore</span>
+        <div class="navbar-links">
+            <a href="{{ url_for('home') }}"
+               class="navbar-link {% if request.endpoint == 'home' %}active{% endif %}">Home</a>
+            <a href="{{ url_for('social') }}"
+               class="navbar-link {% if request.endpoint == 'social' %}active{% endif %}">Social</a>
+            <a href="{{ url_for('log') }}"
+               class="navbar-link {% if request.endpoint == 'log' %}active{% endif %}">Log Exercise</a>
+            <a href="{{ url_for('leaderboard') }}"
+               class="navbar-link {% if request.endpoint == 'leaderboard' %}active{% endif %}">Leaderboard</a>
+            <a href="{{ url_for('profile') }}" class="navbar-profile-button">
+                <img src="{{ url_for('static', filename='images/generic_profile_pic.png') }}"
+                     alt="Profile Picture" class="profile-pic">
+            </a>
+        </div>
+    </nav>
+
+    {% block content %}{% endblock %}
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    {% block extra_js %}{% endblock %}
+</body>
+</html>


### PR DESCRIPTION
Adds base.html as the shared parent template for all main pages. Contains the HTML boilerplate, bootstrap imports, styles.css link, and navbar with active link detection via request.endpoint.

Defines four blocks for child templates to override:
- title: page-specific browser tab title
- extra_css: page-specific stylesheets
- content: page body
- extra_js: page-specific javascript files
