### PR TITLE
Base auth setup

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}FitScore{% endblock %}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+    {% block extra_css %}{% endblock %}
+</head>
+<body>
+
+    <!-- Navbar -->
+    <nav class="navbar navbar-dark px-4">
+        <span class="navbar-brand">FitScore</span>
+        <div class="navbar-links">
+            <a href="{{ url_for('home') }}"
+               class="navbar-link {% if request.endpoint == 'home' %}active{% endif %}">Home</a>
+            <a href="{{ url_for('social') }}"
+               class="navbar-link {% if request.endpoint == 'social' %}active{% endif %}">Social</a>
+            <a href="{{ url_for('log') }}"
+               class="navbar-link {% if request.endpoint == 'log' %}active{% endif %}">Log Exercise</a>
+            <a href="{{ url_for('leaderboard') }}"
+               class="navbar-link {% if request.endpoint == 'leaderboard' %}active{% endif %}">Leaderboard</a>
+            <a href="{{ url_for('profile') }}" class="navbar-profile-button">
+                <img src="{{ url_for('static', filename='images/generic_profile_pic.png') }}"
+                     alt="Profile Picture" class="profile-pic">
+            </a>
+        </div>
+    </nav>
+
+    {% block content %}{% endblock %}
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    {% block extra_js %}{% endblock %}
+</body>
+</html>

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}FitScore{% endblock %}</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
     {% block extra_css %}{% endblock %}
 </head>

--- a/templates/base_auth.html
+++ b/templates/base_auth.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}FitScore{% endblock %}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='login-reg-styles.css') }}">
+    {% block extra_css %}{% endblock %}
+</head>
+<body>
+
+    <!-- Minimal navbar — no nav links for unauthenticated pages -->
+    <nav class="navbar navbar-dark px-4">
+        <a href="{{ url_for('index') }}" class="navbar-brand">FitScore</a>
+        <a href="{{ url_for('login') }}" class="btn btn-primary">Log In</a>
+    </nav>
+
+    {% block content %}{% endblock %}
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    {% block extra_js %}{% endblock %}
+</body>
+</html>

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -1,27 +1,8 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>FitScore - Leaderboard</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
-</head>
-<body>
+{% extends "base.html" %}
 
-    <!-- Navbar -->
-    <nav class="navbar navbar-dark px-4">
-        <span class="navbar-brand">FitScore</span>
-        <div class="navbar-links">
-            <a href="{{ url_for('home') }}" class="navbar-link">Home</a>
-            <a href="{{ url_for('social') }}" class="navbar-link">Social</a>
-            <a href="{{ url_for('log') }}" class="navbar-link">Log Exercise</a>
-            <a href="{{ url_for('leaderboard') }}" class="navbar-link">Leaderboard</a>
-            <a href="{{ url_for('profile') }}" class="navbar-profile-button">
-                <img src="{{ url_for('static', filename='images/generic_profile_pic.png') }}" alt="Profile Picture" class="profile-pic">
-            </a>
-        </div>
-    </nav>
+{% block title %}FitScore - Leaderboard{% endblock %}
+
+{% block content %}
 
     <!-- Page Header -->
     <div class="container py-5">
@@ -139,7 +120,8 @@
         </table>
     </div>
 
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+{% endblock %}
+
+{% block extra_js %}
     <script src="{{ url_for('static', filename='leaderboard.js') }}"></script>
-</body>
-</html>
+{% endblock %}

--- a/templates/log.html
+++ b/templates/log.html
@@ -1,27 +1,8 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>FitScore - Log Exercise</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
-</head>
-<body>
+{% extends "base.html" %}
 
-    <!-- Navbar -->
-    <nav class="navbar navbar-dark px-4">
-        <span class="navbar-brand">FitScore</span>
-        <div class="navbar-links">
-            <a href="{{ url_for('home') }}" class="navbar-link">Home</a>
-            <a href="{{ url_for('social') }}" class="navbar-link">Social</a>
-            <a href="{{ url_for('log') }}" class="navbar-link">Log Exercise</a>
-            <a href="{{ url_for('leaderboard') }}" class="navbar-link">Leaderboard</a>
-            <a href="{{ url_for('profile') }}" class="navbar-profile-button">
-                <img src="{{ url_for('static', filename='images/generic_profile_pic.png') }}" alt="Profile Picture" class="profile-pic">
-            </a>
-        </div>
-    </nav>
+{% block title %}FitScore - Log Exercise{% endblock %}
+
+{% block content %}
 
     <!-- Page Header -->
     <div class="container py-5">
@@ -44,7 +25,7 @@
     <!-- SPORT-SPECIFIC FORM SECTIONS
          All hidden by default — JS reveals the correct
          one when the user picks a sport above. -->
-         
+
     <div class="container pb-5">
 
         <!-- LIFTING -->
@@ -279,7 +260,8 @@
         </div>
     </div>
 
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+{% endblock %}
+
+{% block extra_js %}
     <script src="{{ url_for('static', filename='log.js') }}"></script>
-</body>
-</html>
+{% endblock %}


### PR DESCRIPTION
Adds base_auth.html as the shared parent template for login and register pages. Contains the HTML boilerplate, bootstrap imports, styles.css link with different navbar to other pages. 

Also made small change to base.html to add bootstrap icons as I noticed the social and profile pages will need this support.