### PR TITLE
fix:define recent_log_score before passing to home template

### DIFF
--- a/app.py
+++ b/app.py
@@ -89,7 +89,9 @@ def home():
         if log.standardised_score is not None
     }
     
-    return render_template('home.html', 
+    recent_log_score = z_to_percentile(recent_log.standardised_score) if recent_log and recent_log.standardised_score is not None else None
+
+    return render_template('home.html',
                            recent_log=recent_log,
                            recent_log_score=recent_log_score,
                            performance_labels=performance_labels,


### PR DESCRIPTION
recent_log_score was referenced in the render_template call but never defined, causing a NameError on /home. Added the missing assignment using z_to_percentile() with a None guard, consistent with how friend_log_scores is handled in the same route. 