### PR TITLE
Fixes 107 - wrong 'friend scores' format on social page

### DIFF
--- a/app.py
+++ b/app.py
@@ -318,7 +318,13 @@ def social():
             'days_left': days_left
         })
 
-    return render_template('social.html', recent_friend_logs=recent_friend_logs, friends_leaderboard=friends_leaderboard, events=event_data)
+        friend_log_scores = {
+            log.log_id: z_to_percentile(log.standardised_score)
+            for log in recent_friend_logs
+            if log.standardised_score is not None
+        }
+
+    return render_template('social.html', recent_friend_logs=recent_friend_logs, friends_leaderboard=friends_leaderboard, events=event_data, friend_log_scores=friend_log_scores)
 
 @app.route('/add_friend', methods=['POST'])
 @login_required

--- a/templates/social.html
+++ b/templates/social.html
@@ -35,7 +35,7 @@
                                 <div class="activity-content">
                                     <strong>{{ log.exercise.exercise_name }}:</strong> Completed with a value of {{ log.stat_value | abs if log.stat_value < 0 else log.stat_value }} {{ log.exercise.units }}.
                                     <div class="activity-stats">
-                                        <span><i class="bi bi-activity"></i> Score: {{ "%.2f"|format(log.standardised_score) if log.standardised_score is not none else "N/A" }}</span>
+                                        <span><i class="bi bi-activity"></i> Score: {{ friend_log_scores[log.log_id] if log.log_id in friend_log_scores else "N/A" }}</span>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
Fixes #107
- changed the format for scoring on the 'social' page so it is in line with the home page
- previously showed the raw score (decimal format_
- now shows standardised score (0 - 100)
- added the route to app.py to feed to social.html